### PR TITLE
improvements to the default config

### DIFF
--- a/debian/LatexMk
+++ b/debian/LatexMk
@@ -1,2 +1,3 @@
 $pdf_previewer     = 'start xpdf';
 $pdf_update_method = 1;
+$pdf_mode = 4;

--- a/debian/LatexMk
+++ b/debian/LatexMk
@@ -1,3 +1,1 @@
-$pdf_previewer     = 'start xpdf';
-$pdf_update_method = 1;
 $pdf_mode = 4;


### PR DESCRIPTION
1. The default pdf viewer should not be set if it isn't ensured that it is installed (which it is not afaict).
2. The default update method setting in unnecessary, see [man page](https://manpages.debian.org/unstable/latexmk/latexmk.1.en.html).
2. The default mode should be pdf with LuaTeX as it is the most user friendly, since it supports UTF-8 characters and many other features by default, which the pdflatex engine does not.

It can be safe to assmue that LuaTeX is installed since latexmk depends on texlive-latex-base which depends on texlive-binaries which proves luatex.