### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+latexmk (1:4.69a-1) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sun, 26 Apr 2020 14:48:44 +0000
+
 latexmk (1:4.69a-0.1) unstable; urgency=medium
 
   * NMU

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@
 #export DH_OPTIONS=-v
 
 %:
-	dh $@ 
+	dh $@
 
 override_dh_install:
 	dh_install


### PR DESCRIPTION
Fix some issues reported by lintian
* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html))
* Bump debhelper from old 11 to 12. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version.html))
* Set debhelper-compat version in Build-Depends. ([uses-debhelper-compat-file](https://lintian.debian.org/tags/uses-debhelper-compat-file.html))
* Trim trailing whitespace. ([file-contains-trailing-whitespace](https://lintian.debian.org/tags/file-contains-trailing-whitespace.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/latexmk/26c09886-15cd-41ff-84f2-8af4f9806494.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/26c09886-15cd-41ff-84f2-8af4f9806494/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/26c09886-15cd-41ff-84f2-8af4f9806494/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/26c09886-15cd-41ff-84f2-8af4f9806494/diffoscope)).
