### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/debian-tex/latexmk
 
 Package: latexmk
 Architecture: all
-Depends: perl, texlive-latex-base, ${misc:Depends}
+Depends: perl:any, texlive-latex-base, ${misc:Depends}
 Suggests: ghostscript
 Recommends: xpdf | pdf-viewer, gv | postscript-viewer
 Description: Perl script for running LaTeX the correct number of times


### PR DESCRIPTION
Apply hints suggested by the multi-arch hinter.

* latexmk: Add :any qualifier for perl dependency. This fixes: latexmk could have its dependency on perl annotated with :any. ([dep-any](https://wiki.debian.org/MultiArch/Hints#dep-any))

These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/latexmk/647693cf-a88a-4bea-9b8c-96e1fa6d3ea3.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Depends: [-perl,-] {+perl:any,+} texlive-latex-base


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/647693cf-a88a-4bea-9b8c-96e1fa6d3ea3/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/647693cf-a88a-4bea-9b8c-96e1fa6d3ea3/diffoscope)).
