### PR TITLE
Add Multi-Arch: foreign in accordance with the hint.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+latexmk (1:4.70b-0.3) UNRELEASED; urgency=medium
+
+  [ John Scott ]
+  * Add Multi-Arch: foreign in accordance with the hint.
+
+ -- OHURA Makoto <ohura@debian.org>  Tue, 26 Jan 2021 11:23:49 -0500
+
 latexmk (1:4.70b-0.2) unstable; urgency=medium
 
   * NMU

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Vcs-Browser: https://github.com/debian-tex/latexmk
 
 Package: latexmk
 Architecture: all
+Multi-Arch: foreign
 Depends: perl:any, texlive-latex-base, ${misc:Depends}
 Suggests: ghostscript
 Recommends: xpdf | pdf-viewer, gv | postscript-viewer


### PR DESCRIPTION
From the multi-arch spec, to be declared foreign, it should be that
> The package is not co-installable and should be allowed to satisfy the dependencies of a package of another architecture than its own.

I believe the hint is correct and that it's needed to satisfy cross-build dependencies for FLINT.